### PR TITLE
Adding sv_hostname and cleaning the code from strip colors 

### DIFF
--- a/discordban.py
+++ b/discordban.py
@@ -30,6 +30,7 @@ import b3.events
 import datetime
 import urllib2
 import json
+import re
 
 from collections import defaultdict
 from b3.functions import minutesStr
@@ -90,7 +91,7 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         admin = event.data["admin"]
         client = event.client
         reason = event.data["reason"]
-        server = self.stripColors(str(dict['sv_hostname'])).lower()
+        server = self.stripColors(str(dict['sv_hostname'])).title()
 
         if admin == None:
             admin_name = "B3"
@@ -137,7 +138,7 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         admin = event.data["admin"]
         client = event.client
         reason = event.data["reason"]
-	server = self.stripColors(str(dict['sv_hostname'])).lower()
+	server = self.stripColors(str(dict['sv_hostname'])).title()
 		
         if admin == None:
             admin_name = "B3"
@@ -174,7 +175,7 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         """
         data = json.dumps({"embeds": [embed]})
         req = urllib2.Request(self._discordWebhookUrl, data, {
-            "'Content-Type": "application/json",
+            "Content-Type": "application/json",
             "User-Agent": "B3DiscordbanPlugin/1.1" #Is that a real User-Agent? Nope but who cares.
         })
 

--- a/discordban.py
+++ b/discordban.py
@@ -16,10 +16,13 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 
-#Credits 
-#Fenix the orginal author of the irc b3 bot which this plugin is based on.
-#Mordecaii from iG for his lovely discordPush fuction <3.
-#ItsDizzy from aD for the embedded message and some cleanups.
+# Credits
+# Fenix the orginal author of the irc b3 bot which this plugin is based on.
+# Mordecaii from iG for his lovely discordPush fuction <3.
+# ItsDizzy from aD for the embedded message and some cleanups.
+#  03.11.2019 - v1.0.3 - Zwmabro
+#  - get server name automatically by B3
+#  - Clean reason from some characters
 
 __author__ = "Fenix, st0rm, Mordecaii, ItsDizzy"
 __version__ = "1.2"
@@ -59,7 +62,8 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         """
         Load plugin configuration.
         """
-        self._discordWebhookUrl = self.config.get("authentication","webhookUrl")
+        self._discordWebhookUrl = self.config.get(
+            "authentication", "webhookUrl")
 
     def onStartup(self):
         """
@@ -67,15 +71,18 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         """
 
         # register necessary events
-        self.registerEvent(self.console.getEventID("EVT_CLIENT_BAN"), self.onBan)
-        self.registerEvent(self.console.getEventID("EVT_CLIENT_BAN_TEMP"), self.onBan)
-        self.registerEvent(self.console.getEventID("EVT_CLIENT_KICK"), self.onKick)
+        self.registerEvent(self.console.getEventID(
+            "EVT_CLIENT_BAN"), self.onBan)
+        self.registerEvent(self.console.getEventID(
+            "EVT_CLIENT_BAN_TEMP"), self.onBan)
+        self.registerEvent(self.console.getEventID(
+            "EVT_CLIENT_KICK"), self.onKick)
 
         # notice plugin started
         self.debug("plugin started")
 
     def stripColors(self, s):
-        return re.sub('\^[0-9]{1}','',s)
+        return re.sub('\^[0-9]{1}', '', s)
 
     ####################################################################################################################
     #                                                                                                                  #
@@ -97,7 +104,7 @@ class DiscordbanPlugin(b3.plugin.Plugin):
             admin_name = "B3"
         else:
             admin_name = admin.name
-            
+
         embed = {
             "title": "B3 Ban",
             "description": "**%s** Banned **%s**" % (self.stripColors(admin_name), self.stripColors(client.name)),
@@ -116,7 +123,7 @@ class DiscordbanPlugin(b3.plugin.Plugin):
             # if there is a reason attached to the ban, append it to the notice
             embed["fields"].append({
                 "name": "Reason",
-                "value": self.stripColors(reason.replace(',','')),
+                "value": self.stripColors(reason.replace(',', '')),
                 "inline": True
             })
 
@@ -126,7 +133,8 @@ class DiscordbanPlugin(b3.plugin.Plugin):
             duration = minutesStr(event.data['duration'])
 
         # append the duration to the ban notice
-        embed["fields"].append({"name": "Duration", "value": duration, "inline": True})
+        embed["fields"].append(
+            {"name": "Duration", "value": duration, "inline": True})
 
         self.discordEmbeddedPush(embed)
 
@@ -138,8 +146,8 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         admin = event.data["admin"]
         client = event.client
         reason = event.data["reason"]
-	server = self.stripColors(str(dict['sv_hostname'])).title()
-		
+        server = self.stripColors(str(dict['sv_hostname'])).title()
+
         if admin == None:
             admin_name = "B3"
         else:
@@ -163,7 +171,7 @@ class DiscordbanPlugin(b3.plugin.Plugin):
             # if there is a reason attached to the ban, append it to the notice
             embed["fields"].append({
                 "name": "Reason",
-                "value": self.stripColors(reason.replace(',','')),
+                "value": self.stripColors(reason.replace(',', '')),
                 "inline": True
             })
 
@@ -176,12 +184,15 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         data = json.dumps({"embeds": [embed]})
         req = urllib2.Request(self._discordWebhookUrl, data, {
             "Content-Type": "application/json",
-            "User-Agent": "B3DiscordbanPlugin/1.1" #Is that a real User-Agent? Nope but who cares.
+            # Is that a real User-Agent? Nope but who cares.
+            "User-Agent": "B3DiscordbanPlugin/1.1"
         })
 
         # Final magic happens here, we will never get an error ofcourse ;)
         try:
             urllib2.urlopen(req)
         except urllib2.HTTPError as ex:
-            self.debug("Cannot push data to Discord. is your webhook url right?")
-            self.debug("Data: %s\nCode: %s\nRead: %s" % (data, ex.code, ex.read()))
+            self.debug(
+                "Cannot push data to Discord. is your webhook url right?")
+            self.debug("Data: %s\nCode: %s\nRead: %s" %
+                       (data, ex.code, ex.read()))

--- a/discordban.py
+++ b/discordban.py
@@ -31,6 +31,7 @@ import datetime
 import urllib2
 import json
 
+from collections import defaultdict
 from b3.functions import minutesStr
 
 
@@ -58,7 +59,6 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         Load plugin configuration.
         """
         self._discordWebhookUrl = self.config.get("authentication","webhookUrl")
-        self._serverName = self.config.get("authentication","hostname")
 
     def onStartup(self):
         """
@@ -72,6 +72,9 @@ class DiscordbanPlugin(b3.plugin.Plugin):
 
         # notice plugin started
         self.debug("plugin started")
+
+    def stripColors(self, s):
+        return re.sub('\^[0-9]{1}','',s)
 
     ####################################################################################################################
     #                                                                                                                  #
@@ -87,8 +90,8 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         admin = event.data["admin"]
         client = event.client
         reason = event.data["reason"]
+        server = self.stripColors(str(dict['sv_hostname'])).lower()
 
-        admin_name = ""
         if admin == None:
             admin_name = "B3"
         else:
@@ -96,13 +99,13 @@ class DiscordbanPlugin(b3.plugin.Plugin):
             
         embed = {
             "title": "B3 Ban",
-            "description": "**%s** Banned **%s**" % (admin_name, client.name),
+            "description": "**%s** Banned **%s**" % (self.stripColors(admin_name), self.stripColors(client.name)),
             "timestamp": datetime.datetime.now().isoformat(),
             "color": 15466496,
             "fields": [
                 {
                     "name": "Server",
-                    "value": self._serverName,
+                    "value": server,
                     "inline": False
                 }
             ]
@@ -112,11 +115,11 @@ class DiscordbanPlugin(b3.plugin.Plugin):
             # if there is a reason attached to the ban, append it to the notice
             embed["fields"].append({
                 "name": "Reason",
-                "value": self.console.stripColors(reason),
+                "value": self.stripColors(reason.replace(',','')),
                 "inline": True
             })
 
-        duration = 'permanent'
+        duration = "permanent"
         if 'duration' in event.data:
             # if there is a duration convert it
             duration = minutesStr(event.data['duration'])
@@ -134,8 +137,8 @@ class DiscordbanPlugin(b3.plugin.Plugin):
         admin = event.data["admin"]
         client = event.client
         reason = event.data["reason"]
+	server = self.stripColors(str(dict['sv_hostname'])).lower()
 		
-        admin_name = ""
         if admin == None:
             admin_name = "B3"
         else:
@@ -143,13 +146,13 @@ class DiscordbanPlugin(b3.plugin.Plugin):
 
         embed = {
             "title": "B3 Kick",
-            "description": "**%s** Kicked **%s**" % (admin_name, client.name),
+            "description": "**%s** Kicked **%s**" % (self.stripColors(admin_name), self.stripColors(client.name)),
             "timestamp": datetime.datetime.now().isoformat(),
             "color": 15466496,
             "fields": [
                 {
                     "name": "Server",
-                    "value": self._serverName,
+                    "value": server,
                     "inline": False
                 }
             ]
@@ -159,7 +162,7 @@ class DiscordbanPlugin(b3.plugin.Plugin):
             # if there is a reason attached to the ban, append it to the notice
             embed["fields"].append({
                 "name": "Reason",
-                "value": self.console.stripColors(reason),
+                "value": self.stripColors(reason.replace(',','')),
                 "inline": True
             })
 

--- a/plugin_discordban.xml
+++ b/plugin_discordban.xml
@@ -1,6 +1,5 @@
 <configuration plugin="discordban">
   <settings name="authentication">
     <set name="webhookUrl">DISCORD WEBHOOK HERE</set>
-	<set name="hostname">SERVERNAME</set>
   </settings>
 </configuration>


### PR DESCRIPTION
No need to add your server name every time you hosting a new server, B3 can do that for you by adding `sv_hostname`. 
I added strip color to remove "funny" characters from players and admins names, because some players using discord format character on their Names IG.

_forget my english_